### PR TITLE
Use `java.awt.GraphicsDevice` instead of `sun.awt.Win32GraphicsDevice`

### DIFF
--- a/client/src/Class7.java
+++ b/client/src/Class7.java
@@ -2,8 +2,6 @@
  * Visit http://jode.sourceforge.net/
  */
 
-import sun.awt.Win32GraphicsDevice;
-
 import java.awt.*;
 import java.lang.reflect.Field;
 
@@ -77,7 +75,7 @@ public final class Class7 {
         boolean bool = false;
         if (i <= 47) method212(null, (byte) -25);
         try {
-            Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+            Field field = GraphicsDevice.class.getDeclaredField("valid");
             field.setAccessible(true);
             boolean bool_7_ = ((Boolean) field.get(aGraphicsDevice157)).booleanValue();
             if (bool_7_) {
@@ -95,7 +93,7 @@ public final class Class7 {
         } catch (Throwable object) {
             if (bool) {
                 try {
-                    Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+                    Field field = GraphicsDevice.class.getDeclaredField("valid");
                     field.set(aGraphicsDevice157, Boolean.TRUE);
                 } catch (Exception e) {
                     if (Loader.trace) {
@@ -106,7 +104,7 @@ public final class Class7 {
         }
         if (bool) {
             try {
-                Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+                Field field = GraphicsDevice.class.getDeclaredField("valid");
                 field.set(aGraphicsDevice157, Boolean.TRUE);
             } catch (Throwable throwable) {
                 if (Loader.trace) {


### PR DESCRIPTION
Since the `sun.awt.Win32GraphicsDevice` class is not in the JRE/JDK of non-Windows platforms, it is impossible to compile or run without errors the program on these platforms. The solution is to use the abstract `java.awt.GraphicsDevice` class which is platform-agnostic instead of `sun.awt.Win32GraphicsDevice` which is the platform-specific implementation for Windows. Also `sun.awt.Win32GraphicsDevice` is a proprietary class of Sun/Oracle available only in their JVM which limits portability (see [FAQ - Sun Packages](https://www.oracle.com/java/technologies/faq-sun-packages.html) for more info). On the other hand, `java.awt.GraphicsDevice` is part of the Java SE Platform and should be available in any of its implementations. This should fix the error described in issue #4.