### PR TITLE
Linux/JDK compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ fabric.properties
 *.tar.gz
 *.rar
 
+# local build output
+/build/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ fabric.properties
 # local build output
 /build/
 
+# local JDK installs (bootstrapped)
+/.jdk/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+SHELL := bash
+
+SRC_DIR ?= client/src
+BUILD_DIR ?= build
+CLASSES_DIR ?= $(BUILD_DIR)/classes
+SOURCES_FILE ?= $(BUILD_DIR)/sources.txt
+
+LIBS ?= libs/clientlibs.jar
+MAIN_CLASS ?= Loader
+OUT_JAR ?= $(BUILD_DIR)/void-client.jar
+
+ifdef JAVA_HOME
+JAVA := $(JAVA_HOME)/bin/java
+JAVAC := $(JAVA_HOME)/bin/javac
+JAR := $(JAVA_HOME)/bin/jar
+else
+JAVA ?= java
+JAVAC ?= javac
+JAR ?= jar
+endif
+
+.PHONY: help sources compile jar run clean
+
+help:
+	@echo "Targets:"
+	@echo "  make sources   - write $(SOURCES_FILE)"
+	@echo "  make compile   - compile $(SRC_DIR) into $(CLASSES_DIR)"
+	@echo "  make jar       - build runnable jar at $(OUT_JAR) (Main-Class: $(MAIN_CLASS))"
+	@echo "  make run       - run $(MAIN_CLASS) using $(OUT_JAR) + $(LIBS)"
+	@echo "  make clean     - remove $(BUILD_DIR)"
+	@echo ""
+	@echo "Vars:"
+	@echo "  JAVA_HOME=/path/to/jdk   (use a specific JDK)"
+	@echo "  LIBS=libs/clientlibs.jar (classpath deps)"
+
+sources:
+	@mkdir -p "$(BUILD_DIR)"
+	@find "$(SRC_DIR)" -maxdepth 1 -name '*.java' -print | sort > "$(SOURCES_FILE)"
+	@echo "Wrote $(SOURCES_FILE) ($$(wc -l < "$(SOURCES_FILE)") files)"
+
+compile: sources
+	@mkdir -p "$(CLASSES_DIR)"
+	@echo "Compiling with: $(JAVAC)"
+	@"$(JAVAC)" -Xlint:none -cp "$(LIBS)" -d "$(CLASSES_DIR)" @"$(SOURCES_FILE)"
+
+jar: compile
+	@mkdir -p "$(BUILD_DIR)"
+	@echo "Jarring to: $(OUT_JAR)"
+	@"$(JAR)" cfe "$(OUT_JAR)" "$(MAIN_CLASS)" -C "$(CLASSES_DIR)" .
+
+run: jar
+	@"$(JAVA)" -cp "$(OUT_JAR):$(LIBS)" "$(MAIN_CLASS)"
+
+clean:
+	rm -rf "$(BUILD_DIR)"
+

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,39 @@ LIBS ?= libs/clientlibs.jar
 MAIN_CLASS ?= Loader
 OUT_JAR ?= $(BUILD_DIR)/void-client.jar
 
+# Requested JDK major version. Used to validate JAVA_HOME and auto-select a bootstrapped JDK under ./.jdk/.
+JDK ?= 8
+BOOTSTRAP_JAVA_HOME ?= $(CURDIR)/.jdk/temurin$(JDK)
+
+# If JAVA_HOME isn't set (or doesn't match JDK), fall back to a repo-local bootstrapped JDK if present.
+JAVA_HOME_BIN_JAVA := $(JAVA_HOME)/bin/java
+JAVA_HOME_BIN_JAVAC := $(JAVA_HOME)/bin/javac
+
+ifdef JAVA_HOME
+  ifeq ($(wildcard $(JAVA_HOME_BIN_JAVA)),)
+    ifneq ($(wildcard $(BOOTSTRAP_JAVA_HOME)/bin/java),)
+      $(warning JAVA_HOME is set but invalid ($(JAVA_HOME_BIN_JAVA) missing); using $(BOOTSTRAP_JAVA_HOME))
+      JAVA_HOME := $(BOOTSTRAP_JAVA_HOME)
+    else
+      $(warning JAVA_HOME is set but invalid ($(JAVA_HOME_BIN_JAVA) missing); falling back to PATH)
+    endif
+  else
+    JAVA_HOME_MAJOR := $(shell "$(JAVA_HOME_BIN_JAVA)" -version 2>&1 | sed -n '1{s/.*version \"1\.\([0-9][0-9]*\).*/\1/p; s/.*version \"\([0-9][0-9]*\).*/\1/p;}')
+    ifneq ($(JAVA_HOME_MAJOR),$(JDK))
+      ifneq ($(wildcard $(BOOTSTRAP_JAVA_HOME)/bin/java),)
+        $(warning JAVA_HOME is Java $(JAVA_HOME_MAJOR) but JDK=$(JDK); using $(BOOTSTRAP_JAVA_HOME))
+        JAVA_HOME := $(BOOTSTRAP_JAVA_HOME)
+      else
+        $(warning JAVA_HOME is Java $(JAVA_HOME_MAJOR) but JDK=$(JDK); continuing with JAVA_HOME)
+      endif
+    endif
+  endif
+else
+  ifneq ($(wildcard $(BOOTSTRAP_JAVA_HOME)/bin/java),)
+    JAVA_HOME := $(BOOTSTRAP_JAVA_HOME)
+  endif
+endif
+
 ifdef JAVA_HOME
 JAVA := $(JAVA_HOME)/bin/java
 JAVAC := $(JAVA_HOME)/bin/javac
@@ -30,11 +63,12 @@ help:
 	@echo "  make clean     - remove $(BUILD_DIR)"
 	@echo ""
 	@echo "Vars:"
-	@echo "  JAVA_HOME=/path/to/jdk   (use a specific JDK)"
+	@echo "  JDK=8                    (requested major version; default 8)"
+	@echo "  JAVA_HOME=/path/to/jdk   (used if compatible with JDK; otherwise ./.jdk/temurin\$$JDK is preferred)"
 	@echo "  LIBS=libs/clientlibs.jar (classpath deps)"
 	@echo ""
 	@echo "Tip:"
-	@echo "  tools/bootstrap-jdk.sh 8  (downloads a repo-local JDK into .jdk/)"
+	@echo "  tools/bootstrap-jdk.sh \$$JDK  (downloads a repo-local JDK into .jdk/)"
 
 sources:
 	@mkdir -p "$(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SOURCES_FILE ?= $(BUILD_DIR)/sources.txt
 LIBS ?= libs/clientlibs.jar
 MAIN_CLASS ?= Loader
 OUT_JAR ?= $(BUILD_DIR)/void-client.jar
+CLASSES_STAMP ?= $(CLASSES_DIR)/.compiled.stamp
 
 # Requested JDK major version. Used to validate JAVA_HOME and auto-select a bootstrapped JDK under ./.jdk/.
 JDK ?= 8
@@ -75,22 +76,34 @@ bootstrap:
 	@echo "Bootstrapping Temurin JDK $(JDK) into $(BOOTSTRAP_JAVA_HOME)"
 	@bash tools/bootstrap-jdk.sh "$(JDK)"
 
-sources:
-	@mkdir -p "$(BUILD_DIR)"
+JAVA_SOURCES := $(wildcard $(SRC_DIR)/*.java)
+LIB_JARS := $(subst :, ,$(LIBS))
+
+$(BUILD_DIR):
+	@mkdir -p "$@"
+
+$(CLASSES_DIR):
+	@mkdir -p "$@"
+
+sources: $(BUILD_DIR)
 	@find "$(SRC_DIR)" -maxdepth 1 -name '*.java' -print | sort > "$(SOURCES_FILE)"
 	@echo "Wrote $(SOURCES_FILE) ($$(wc -l < "$(SOURCES_FILE)") files)"
 
-compile: sources
-	@mkdir -p "$(CLASSES_DIR)"
+$(CLASSES_STAMP): $(JAVA_SOURCES) $(LIB_JARS) | $(CLASSES_DIR) $(BUILD_DIR)
 	@echo "Compiling with: $(JAVAC)"
+	@find "$(SRC_DIR)" -maxdepth 1 -name '*.java' -print | sort > "$(SOURCES_FILE)"
 	@"$(JAVAC)" -Xlint:none -cp "$(LIBS)" -d "$(CLASSES_DIR)" @"$(SOURCES_FILE)"
+	@touch "$(CLASSES_STAMP)"
 
-jar: compile
-	@mkdir -p "$(BUILD_DIR)"
+compile: $(CLASSES_STAMP)
+
+$(OUT_JAR): $(CLASSES_STAMP) | $(BUILD_DIR)
 	@echo "Jarring to: $(OUT_JAR)"
 	@"$(JAR)" cfe "$(OUT_JAR)" "$(MAIN_CLASS)" -C "$(CLASSES_DIR)" .
 
-run: jar
+jar: $(OUT_JAR)
+
+run: $(OUT_JAR)
 	@"$(JAVA)" -cp "$(OUT_JAR):$(LIBS)" "$(MAIN_CLASS)"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ help:
 	@echo "Vars:"
 	@echo "  JAVA_HOME=/path/to/jdk   (use a specific JDK)"
 	@echo "  LIBS=libs/clientlibs.jar (classpath deps)"
+	@echo ""
+	@echo "Tip:"
+	@echo "  tools/bootstrap-jdk.sh 8  (downloads a repo-local JDK into .jdk/)"
 
 sources:
 	@mkdir -p "$(BUILD_DIR)"
@@ -53,4 +56,3 @@ run: jar
 
 clean:
 	rm -rf "$(BUILD_DIR)"
-

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,11 @@ JAVAC ?= javac
 JAR ?= jar
 endif
 
-.PHONY: help sources compile jar run clean
+.PHONY: help bootstrap sources compile jar run clean
 
 help:
 	@echo "Targets:"
+	@echo "  make bootstrap - download repo-local JDK (./.jdk/temurin\$$JDK)"
 	@echo "  make sources   - write $(SOURCES_FILE)"
 	@echo "  make compile   - compile $(SRC_DIR) into $(CLASSES_DIR)"
 	@echo "  make jar       - build runnable jar at $(OUT_JAR) (Main-Class: $(MAIN_CLASS))"
@@ -69,6 +70,10 @@ help:
 	@echo ""
 	@echo "Tip:"
 	@echo "  tools/bootstrap-jdk.sh \$$JDK  (downloads a repo-local JDK into .jdk/)"
+
+bootstrap:
+	@echo "Bootstrapping Temurin JDK $(JDK) into $(BOOTSTRAP_JAVA_HOME)"
+	@bash tools/bootstrap-jdk.sh "$(JDK)"
 
 sources:
 	@mkdir -p "$(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ LIBS ?= libs/clientlibs.jar
 MAIN_CLASS ?= Loader
 OUT_JAR ?= $(BUILD_DIR)/void-client.jar
 CLASSES_STAMP ?= $(CLASSES_DIR)/.compiled.stamp
+JAVA_ARGS ?=
 
 # Requested JDK major version. Used to validate JAVA_HOME and auto-select a bootstrapped JDK under ./.jdk/.
 JDK ?= 8
@@ -104,7 +105,7 @@ $(OUT_JAR): $(CLASSES_STAMP) | $(BUILD_DIR)
 jar: $(OUT_JAR)
 
 run: $(OUT_JAR)
-	@"$(JAVA)" -cp "$(OUT_JAR):$(LIBS)" "$(MAIN_CLASS)"
+	@"$(JAVA)" $(JAVA_ARGS) -cp "$(OUT_JAR):$(LIBS)" "$(MAIN_CLASS)"
 
 clean:
 	rm -rf "$(BUILD_DIR)"

--- a/client/src/Class258_Sub3.java
+++ b/client/src/Class258_Sub3.java
@@ -5,7 +5,11 @@
 import jaggl.OpenGL;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.awt.image.PixelGrabber;
+import java.io.ByteArrayInputStream;
+
+import javax.imageio.ImageIO;
 
 class Class258_Sub3 extends Class258 {
     static int anInt8539;
@@ -185,6 +189,20 @@ class Class258_Sub3 extends Class258 {
         anInt8546++;
         if (i != -5901) anInt8550 = 83;
         if (is == null) throw new RuntimeException("");
+        try {
+            BufferedImage bufferedimage = ImageIO.read(new ByteArrayInputStream(is));
+            if (bufferedimage != null) {
+                int i_58_ = bufferedimage.getWidth();
+                int i_59_ = bufferedimage.getHeight();
+                if (i_58_ > 0 && i_59_ > 0) {
+                    int[] is_60_ = new int[i_59_ * i_58_];
+                    bufferedimage.getRGB(0, 0, i_58_, i_59_, is_60_, 0, i_58_);
+                    return Class348_Sub8.aHa6654.method3662(i_58_, is_60_, (byte) 94, 0, i_58_, i_59_);
+                }
+            }
+        } catch (Throwable throwable) {
+            /* fall back to AWT toolkit image decoding below */
+        }
         for (; ; ) {
             try {
                 Image image = Toolkit.getDefaultToolkit().createImage(is);

--- a/client/src/Class258_Sub3.java
+++ b/client/src/Class258_Sub3.java
@@ -201,24 +201,36 @@ class Class258_Sub3 extends Class258 {
                 }
             }
         } catch (Throwable throwable) {
-            /* fall back to AWT toolkit image decoding below */
+            /* fall through */
         }
-        for (; ; ) {
-            try {
-                Image image = Toolkit.getDefaultToolkit().createImage(is);
-                MediaTracker mediatracker = new MediaTracker(Class79.aClient1367);
-                mediatracker.addImage(image, 0);
-                mediatracker.waitForAll();
-                int i_58_ = image.getWidth(Class79.aClient1367);
-                int i_59_ = image.getHeight(Class79.aClient1367);
-                if (mediatracker.isErrorAny() || i_58_ < 0 || i_59_ < 0) throw new RuntimeException("");
-                int[] is_60_ = new int[i_59_ * i_58_];
-                PixelGrabber pixelgrabber = new PixelGrabber(image, 0, 0, i_58_, i_59_, is_60_, 0, i_58_);
-                pixelgrabber.grabPixels();
-                return Class348_Sub8.aHa6654.method3662(i_58_, is_60_, (byte) 94, 0, i_58_, i_59_);
-            } catch (InterruptedException interruptedexception) {
-                /* empty */
+
+        if (Boolean.getBoolean("voidclient.image.awt_fallback")) {
+            for (; ; ) {
+                try {
+                    Image image = Toolkit.getDefaultToolkit().createImage(is);
+                    MediaTracker mediatracker = new MediaTracker(Class79.aClient1367);
+                    mediatracker.addImage(image, 0);
+                    mediatracker.waitForAll();
+                    int i_58_ = image.getWidth(Class79.aClient1367);
+                    int i_59_ = image.getHeight(Class79.aClient1367);
+                    if (mediatracker.isErrorAny() || i_58_ < 0 || i_59_ < 0) throw new RuntimeException("");
+                    int[] is_60_ = new int[i_59_ * i_58_];
+                    PixelGrabber pixelgrabber = new PixelGrabber(image, 0, 0, i_58_, i_59_, is_60_, 0, i_58_);
+                    pixelgrabber.grabPixels();
+                    return Class348_Sub8.aHa6654.method3662(i_58_, is_60_, (byte) 94, 0, i_58_, i_59_);
+                } catch (InterruptedException interruptedexception) {
+                    /* empty */
+                }
             }
+        }
+
+        try {
+            if (Loader.trace) {
+                System.err.println("Image decode failed; returning placeholder sprite. Set -Dvoidclient.image.awt_fallback=true to use Toolkit decoding.");
+            }
+            return Class348_Sub8.aHa6654.method3662(1, new int[]{0}, (byte) 94, 0, 1, 1);
+        } catch (Throwable throwable) {
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/client/src/Class7.java
+++ b/client/src/Class7.java
@@ -1,9 +1,6 @@
 /* Class7 - Decompiled by JODE
  * Visit http://jode.sourceforge.net/
  */
-
-import sun.awt.Win32GraphicsDevice;
-
 import java.awt.*;
 import java.lang.reflect.Field;
 
@@ -77,7 +74,8 @@ public final class Class7 {
         boolean bool = false;
         if (i <= 47) method212(null, (byte) -25);
         try {
-            Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+            Class<?> win32GraphicsDevice = Class.forName("sun.awt.Win32GraphicsDevice");
+            Field field = win32GraphicsDevice.getDeclaredField("valid");
             field.setAccessible(true);
             boolean bool_7_ = ((Boolean) field.get(aGraphicsDevice157)).booleanValue();
             if (bool_7_) {
@@ -95,7 +93,8 @@ public final class Class7 {
         } catch (Throwable object) {
             if (bool) {
                 try {
-                    Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+                    Class<?> win32GraphicsDevice = Class.forName("sun.awt.Win32GraphicsDevice");
+                    Field field = win32GraphicsDevice.getDeclaredField("valid");
                     field.set(aGraphicsDevice157, Boolean.TRUE);
                 } catch (Exception e) {
                     if (Loader.trace) {
@@ -106,7 +105,8 @@ public final class Class7 {
         }
         if (bool) {
             try {
-                Field field = Win32GraphicsDevice.class.getDeclaredField("valid");
+                Class<?> win32GraphicsDevice = Class.forName("sun.awt.Win32GraphicsDevice");
+                Field field = win32GraphicsDevice.getDeclaredField("valid");
                 field.set(aGraphicsDevice157, Boolean.TRUE);
             } catch (Throwable throwable) {
                 if (Loader.trace) {

--- a/tools/bootstrap-jdk.sh
+++ b/tools/bootstrap-jdk.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+JDK_MAJOR="${1:-8}"
+
+case "${JDK_MAJOR}" in
+  8|11|17|21) ;;
+  *)
+    echo "Usage: tools/bootstrap-jdk.sh {8|11|17|21}"
+    echo "Downloads an Eclipse Temurin JDK into $ROOT_DIR/.jdk/temurin<JDK_MAJOR> (no Gradle, no system install)."
+    exit 2
+    ;;
+esac
+
+OS="linux"
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="x64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *)
+    echo "Unsupported arch: $ARCH_RAW"
+    exit 2
+    ;;
+esac
+
+DEST_DIR="$ROOT_DIR/.jdk/temurin${JDK_MAJOR}"
+TMP_DIR="${DEST_DIR}.tmp.$$"
+ARCHIVE="/tmp/temurin${JDK_MAJOR}-${OS}-${ARCH}-jdk.tar.gz"
+
+URL="https://api.adoptium.net/v3/binary/latest/${JDK_MAJOR}/ga/${OS}/${ARCH}/jdk/hotspot/normal/eclipse"
+
+echo "Downloading Temurin JDK ${JDK_MAJOR} for ${OS}/${ARCH}..."
+echo "  $URL"
+curl -fsSL -o "$ARCHIVE" "$URL"
+
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+
+echo "Extracting to $DEST_DIR ..."
+tar -xzf "$ARCHIVE" -C "$TMP_DIR" --strip-components=1
+
+rm -rf "$DEST_DIR"
+mv "$TMP_DIR" "$DEST_DIR"
+
+cat <<EOF
+Done.
+
+Use it for builds:
+  export JAVA_HOME="$DEST_DIR"
+  export PATH="\$JAVA_HOME/bin:\$PATH"
+
+Then:
+  make jar
+or:
+  tools/build.sh
+EOF
+

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SRC_DIR="${SRC_DIR:-"$ROOT_DIR/client/src"}"
+BUILD_DIR="${BUILD_DIR:-"$ROOT_DIR/build"}"
+CLASSES_DIR="${CLASSES_DIR:-"$BUILD_DIR/classes"}"
+SOURCES_FILE="${SOURCES_FILE:-"$BUILD_DIR/sources.txt"}"
+
+LIBS="${LIBS:-"$ROOT_DIR/libs/clientlibs.jar"}"
+MAIN_CLASS="${MAIN_CLASS:-Loader}"
+OUT_JAR="${OUT_JAR:-"$BUILD_DIR/void-client.jar"}"
+
+JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+JAVAC_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}javac"
+JAR_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}jar"
+
+EXCLUDE_REGEX="${EXCLUDE_REGEX:-}"
+
+mkdir -p "$BUILD_DIR" "$CLASSES_DIR"
+
+find "$SRC_DIR" -maxdepth 1 -name '*.java' -print | sort > "$SOURCES_FILE"
+if [[ -n "$EXCLUDE_REGEX" ]]; then
+  grep -Ev "$EXCLUDE_REGEX" "$SOURCES_FILE" > "$SOURCES_FILE.tmp"
+  mv "$SOURCES_FILE.tmp" "$SOURCES_FILE"
+fi
+
+echo "Sources: $(wc -l < "$SOURCES_FILE") ($SOURCES_FILE)"
+echo "JAVAC: $JAVAC_BIN"
+
+"$JAVAC_BIN" -Xlint:none -cp "$LIBS" -d "$CLASSES_DIR" @"$SOURCES_FILE"
+
+echo "JAR: $OUT_JAR"
+"$JAR_BIN" cfe "$OUT_JAR" "$MAIN_CLASS" -C "$CLASSES_DIR" .
+
+echo "Done. Run with:"
+echo "  $JAVA_BIN -cp $OUT_JAR:$LIBS $MAIN_CLASS"
+

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BUILD_DIR="${BUILD_DIR:-"$ROOT_DIR/build"}"
+LIBS="${LIBS:-"$ROOT_DIR/libs/clientlibs.jar"}"
+MAIN_CLASS="${MAIN_CLASS:-Loader}"
+OUT_JAR="${OUT_JAR:-"$BUILD_DIR/void-client.jar"}"
+
+JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+if [[ ! -f "$OUT_JAR" ]]; then
+  echo "Missing $OUT_JAR. Build first with:"
+  echo "  make jar"
+  echo "or"
+  echo "  tools/build.sh"
+  exit 1
+fi
+
+exec "$JAVA_BIN" -cp "$OUT_JAR:$LIBS" "$MAIN_CLASS" "$@"
+

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -9,6 +9,9 @@ MAIN_CLASS="${MAIN_CLASS:-Loader}"
 OUT_JAR="${OUT_JAR:-"$BUILD_DIR/void-client.jar"}"
 
 JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+JAVA_ARGS="${JAVA_ARGS:-}"
+
+read -r -a JAVA_ARGS_ARR <<<"$JAVA_ARGS"
 
 if [[ ! -f "$OUT_JAR" ]]; then
   echo "Missing $OUT_JAR. Build first with:"
@@ -18,5 +21,4 @@ if [[ ! -f "$OUT_JAR" ]]; then
   exit 1
 fi
 
-exec "$JAVA_BIN" -cp "$OUT_JAR:$LIBS" "$MAIN_CLASS" "$@"
-
+exec "$JAVA_BIN" "${JAVA_ARGS_ARR[@]}" -cp "$OUT_JAR:$LIBS" "$MAIN_CLASS" "$@"


### PR DESCRIPTION
Stacked on #13.

Fixes Linux/JDK issues:
- Avoid hard dependency on Win32-only AWT internals.
- Prefer ImageIO for byte[] image decode; AWT Toolkit fallback can be re-enabled with -Dvoidclient.image.awt_fallback=true.